### PR TITLE
Implement MIT-MAGIC-COOKIE for unix domain socket connection

### DIFF
--- a/MappedFile.zig
+++ b/MappedFile.zig
@@ -1,0 +1,116 @@
+const MappedFile = @This();
+
+const builtin = @import("builtin");
+const std = @import("std");
+const HANDLE = std.os.windows.HANDLE;
+
+mem: []align(std.mem.page_size) u8,
+mapping: if (builtin.os.tag == .windows) HANDLE else void,
+
+pub const Options = struct {
+    mode: enum { read_only, read_write } = .read_only,
+};
+const empty_mem: [0]u8 align(std.mem.page_size) = undefined;
+
+pub fn init(filename: []const u8, opt: Options) !MappedFile {
+    var file = try std.fs.cwd().openFile(filename, .{});
+    defer file.close();
+    const file_size = try file.getEndPos();
+
+    if (builtin.os.tag == .windows) {
+        if (file_size == 0) return MappedFile{
+            .mem = &empty_mem,
+            .mapping = undefined,
+        };
+
+        const mapping = win32.CreateFileMappingA(
+            file.handle,
+            null,
+            switch (opt.mode) {
+                .read_only => win32.PAGE_READONLY,
+                .read_write => win32.PAGE_READWRITE,
+            },
+            @intCast(0xffffffff & (file_size >> 32)),
+            @intCast(0xffffffff & (file_size)),
+            null,
+        ) orelse return switch (win32.GetLastError()) {
+            .DISK_FULL => |e| switch (opt.mode) {
+                .read_only => std.os.windows.unexpectedError(e),
+                .read_write => error.DiskFull,
+            },
+            else => |err| std.os.windows.unexpectedError(err),
+        };
+        errdefer std.os.windows.CloseHandle(mapping);
+
+        const ptr = win32.MapViewOfFile(
+            mapping,
+            switch (opt.mode) {
+                .read_only => win32.FILE_MAP_READ,
+                .read_write => win32.FILE_MAP_READ | win32.FILE_MAP_READ,
+            },
+            0, 0, 0,
+        ) orelse return switch (win32.GetLastError()) {
+            // TODO: handle some error codes
+            else => |err| std.os.windows.unexpectedError(err),
+        };
+        errdefer std.debug.assert(0 != win32.UnmapViewOfFile(ptr));
+        
+        return .{
+            .mem = @as([*]align(std.mem.page_size)u8, @alignCast(@ptrCast(ptr)))[0 .. file_size],
+            .mapping = mapping,
+        };        
+    }
+    return .{
+        .mem = try std.os.mmap(
+            null,
+            file_size,
+            switch (opt.mode) {
+                .read_only => std.os.PROT.READ,
+                .read_write => std.os.PROT.READ | std.os.PROT.WRITE,
+            },
+            std.os.MAP.PRIVATE,
+            file.handle,
+            0,
+        ),
+        .mapping = {},
+    };    
+}
+             
+pub fn unmap(self: MappedFile) void {
+    if (builtin.os.tag == .windows) {
+        if (self.mem.len != 0) {
+            std.debug.assert(0 != win32.UnmapViewOfFile(self.mem.ptr));
+            std.os.windows.CloseHandle(self.mapping);
+        }
+    } else {
+        std.os.munmap(self.mem);
+    }
+}
+
+const win32 = struct {
+    pub const BOOL = i32;
+    pub const GetLastError = std.os.windows.kernel32.GetLastError;
+    pub const PAGE_READONLY = 2;
+    pub const PAGE_READWRITE = 4;
+    pub extern "kernel32" fn CreateFileMappingA(
+        hFile: ?HANDLE,
+        lpFileMappingAttributes: ?*anyopaque,
+        flProtect: u32,
+        dwMaximumSizeHigh: u32,
+        dwMaximumSizeLow: u32,
+        lpName: ?[*:0]const u8,
+    ) callconv(std.os.windows.WINAPI) ?HANDLE;
+
+    pub const FILE_MAP_WRITE = 2;
+    pub const FILE_MAP_READ = 4;
+    pub extern "kernel32" fn MapViewOfFile(
+        hFileMappingObject: ?HANDLE,
+        dwDesiredAccess: u32,
+        dwFileOffsetHigh: u32,
+        dwFileOffsetLow: u32,
+        dwNumberOfBytesToMap: usize,
+    ) callconv(std.os.windows.WINAPI) ?*anyopaque;
+    pub extern "kernel32" fn UnmapViewOfFile(
+        lpBaseAddress: ?*const anyopaque,
+    ) callconv(std.os.windows.WINAPI) BOOL;
+};

--- a/README.md
+++ b/README.md
@@ -63,12 +63,9 @@ xtrace -n -- zig run example.zig
 
 https://en.wikipedia.org/wiki/X_Window_authorization
 
-I have yet to implement "cookie-based access".  To do so, I need to read the
-cookie from `$HOME/.Xauthority` (or the file from environment variable
-`XAUTHORITY` if it exists).  According to the wiki there are 2 methods
-to sending the cookie, `MIT-MAGIC-COOKIE-1` and `XDM-AUTHORIZATION-1`.
-In the first method the client simply sends the cookie when requested
-to authenticate, in the second method a secret key is also stored in the
-`.Xauthority` file, the client creates a string by concatenating the
-current time, a transport identifier and the cookie, then encrypts
-the resulting string and sends it to the server.
+* `MIT-MAGIC-COOKIE`: implemented for local connections
+* `XDM-AUTHORIZATION-1`: not implemented
+
+For `XDM-AUTHORIZATION-1`, a secret key is stored in the `$HOME/.Xauthority` file, the client creates a string
+by concatenating the current time, a transport identifier and the key, then encrypts the resulting string
+and sends it to the server.

--- a/xauth.zig
+++ b/xauth.zig
@@ -1,0 +1,124 @@
+const std = @import("std");
+const x = @import("x.zig");
+
+const global = struct {
+    pub var arena_instance = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    pub const arena = arena_instance.allocator();
+};
+
+const Opt = struct {
+    auth_filename: ?[]const u8 = null,
+};
+
+fn usage() void {
+    std.debug.print(
+        \\usage: xauth [-options ...] [command arg ...]
+        \\
+        \\OPTIONS:
+        \\  -f  authfilename    Authorization file to use. Optional, defaults to $XAUTHORITY or $HOME/.Xauthority
+        \\
+        \\COMMANDS:
+        \\  help                Print help
+        \\  list                List authorization entries
+        \\
+    , .{});
+}
+
+pub fn main() !void {
+    const all_args = try std.process.argsAlloc(global.arena);
+    // no need to free
+
+    var opt = Opt{};
+    const args = blk: {
+        var new_arg_count: usize = 0;
+        var arg_index: usize = 1;
+        while (arg_index < all_args.len) : (arg_index += 1) {
+            const arg = all_args[arg_index];
+            if (!std.mem.startsWith(u8, arg, "-")) {
+                all_args[new_arg_count] = arg;
+                new_arg_count += 1;
+            } else if (std.mem.eql(u8, arg, "-f")) {
+                arg_index += 1;
+                if (arg_index >= all_args.len) {
+                    std.log.err("missing authfilename after option -f", .{});
+                    std.process.exit(1);
+                }
+                opt.auth_filename = all_args[arg_index];
+            } else {
+                std.log.err("invalid option \"{s}\"", .{arg});
+                std.process.exit(1);
+            }
+        }
+        break :blk all_args[0..new_arg_count];
+    };
+    if (args.len == 0) {
+        usage();
+        return;
+    }
+    const cmd = args[0];
+    const cmd_args = args[1..];
+
+    if (std.mem.eql(u8, cmd, "help")) {
+        usage();
+    } else if (std.mem.eql(u8, cmd, "list")) {
+        try list(opt, cmd_args);
+    } else {
+        std.log.err("invalid command \"{s}\"", .{cmd});
+        std.process.exit(1);
+    }
+}
+
+fn list(opt: Opt, cmd_args: []const [:0]const u8) !void {
+    if (cmd_args.len != 0) {
+        std.log.err("list command doesn't accept any arguments", .{});
+        std.process.exit(1);
+    }
+
+    const auth_filename = blk: {
+        if (opt.auth_filename) |f| break :blk x.AuthFilename{
+            .str = f,
+            .owned = false,
+        };
+        break :blk try x.getAuthFilename(global.arena) orelse {
+            std.log.err("unable to find an Xauthority file", .{});
+            std.process.exit(1);
+        };
+    };
+    // no need to auth_filename.deinit(allocator);
+
+    const auth_mapped = try x.MappedFile.init(auth_filename.str, .{});
+    defer auth_mapped.unmap();
+
+
+    const stdout_writer = std.io.getStdOut().writer();
+    var buffered_writer = std.io.bufferedWriter(stdout_writer);
+    const writer = buffered_writer.writer();
+
+    var auth_it = x.AuthIterator{ .mem = auth_mapped.mem };
+    while (auth_it.next() catch {
+        std.log.err("auth file '{s}' is invalid", .{auth_filename.str});
+        std.process.exit(1);
+    }) |entry| {
+        var family_buf: [5]u8 = undefined;
+        var display_buf: [40]u8 = undefined;
+        const display: []const u8 = if (entry.display_num) |d| (
+            std.fmt.bufPrint(&display_buf, "{}", .{d}) catch unreachable
+        ) else "";
+        try writer.print("{s}/{s}:{s}  {s}  {s}\n", .{
+            entry.addr(auth_mapped.mem),
+            getFamilyString(entry.family, &family_buf),
+            display,
+            entry.name(auth_mapped.mem),
+            std.fmt.fmtSliceHexLower(entry.data(auth_mapped.mem)),
+        });
+    }
+    try buffered_writer.flush();
+}
+
+fn getFamilyString(family: x.AuthFamily, buf: *[5]u8) []const u8 {
+    return switch (family) {
+        .internet => "inet",
+        .local => "unix",
+        else => std.fmt.bufPrint(buf, "{}", .{@intFromEnum(family)}) catch unreachable,
+    };
+}


### PR DESCRIPTION
This is needed on (arch) linux, otherwise you get a connect error
saying that authorization is required.

Right now authorization is ignored for tcp connections
as it works slightly different (needs to get remote hostname)
and I haven't tested that part.

Only tested on linux.