### PR TITLE
Parse the rest of the connection setup buffer to get the screens, depths, and visual types

### DIFF
--- a/x.zig
+++ b/x.zig
@@ -2294,7 +2294,64 @@ pub const Screen = extern struct {
     save_unders: u8,
     root_depth: u8,
     allowed_depth_count: u8,
+    _allowed_depths_array_start: [0]ScreenDepth,
+
+    pub fn getAllowedDepths(self: *@This(), allocator: std.mem.Allocator) ![]align(4) *ScreenDepth {
+        var depths = try allocator.alloc(*ScreenDepth, self.allowed_depth_count);
+        var pointer_offset: usize = 0;
+        for (0..self.allowed_depth_count) |i| {
+            var depth_ptr: *align(4) ScreenDepth = @ptrFromInt(@intFromPtr(&self._allowed_depths_array_start) + pointer_offset);
+
+            depths[i] = depth_ptr;
+
+            const depth_variable_size: usize = @as(usize, @sizeOf(ScreenDepth)) +
+                (@as(usize, @sizeOf(VisualType)) * @as(usize, depth_ptr.visual_type_count));
+            pointer_offset += depth_variable_size;
+        }
+
+        return depths;
+    }
+
+    pub fn findMatchingVisualType(self: *@This(), desired_depth: u8, desired_class: VisualType.Class, allocator: std.mem.Allocator) !VisualType {
+        const depths = try self.getAllowedDepths(allocator);
+        defer allocator.free(depths);
+
+        for (depths) |depth| {
+            if (depth.depth != desired_depth) continue;
+            for (depth.getVisualTypes()) |visual_type| {
+                if (visual_type.class != desired_class) continue;
+                return visual_type;
+            }
+        }
+        return error.VisualTypeNotFound;
+    }
 };
+
+test "VisualType.findMatchingVisualType" {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const connect_setup_stub = ConnectSetup {
+        .buf = TEST_RECEIVED_CONNECT_SETUP_BUFFER[0..],
+    };
+    // We avoid de-initializing to keep the test buffer around for other tests
+    //defer connect_setup_stub.deinit(allocator);
+
+    var screens = try connect_setup_stub.getScreens(allocator);
+
+    const matching_visual_type_24 = try screens[0].findMatchingVisualType(24, .direct_color, allocator);
+    try testing.expectEqual(@as(u32, 1946), matching_visual_type_24.id);
+    try testing.expectEqual(VisualType.Class.direct_color, matching_visual_type_24.class);
+
+    const matching_visual_type_32 = try screens[0].findMatchingVisualType(32, .true_color, allocator);
+    try testing.expectEqual(@as(u32, 124), matching_visual_type_32.id);
+    try testing.expectEqual(VisualType.Class.true_color, matching_visual_type_32.class);
+
+    const depth_that_does_not_exist: u8 = 255;
+    const visual_type_not_found_result = screens[0].findMatchingVisualType(depth_that_does_not_exist, .static_color, allocator);
+    try std.testing.expectError(error.VisualTypeNotFound, visual_type_not_found_result);
+}
 
 comptime { std.debug.assert(@sizeOf(ScreenDepth) == 8); }
 pub const ScreenDepth = extern struct {
@@ -2302,6 +2359,12 @@ pub const ScreenDepth = extern struct {
     unused0: u8,
     visual_type_count: u16,
     unused1: u32,
+    _visual_types_array_start: [0]VisualType,
+
+    pub fn getVisualTypes(self: *@This()) []align(4) const VisualType {
+        const visual_type_ptr_list: [*]align(4) VisualType = @ptrFromInt(@intFromPtr(&self._visual_types_array_start));
+        return visual_type_ptr_list[0..self.visual_type_count];
+    }
 };
 
 comptime { std.debug.assert(@sizeOf(VisualType) == 24); }
@@ -2478,7 +2541,170 @@ pub const ConnectSetup = struct {
     pub fn getScreensPtr(self: @This(), format_list_limit: u32) [*]align(4) Screen {
         return @alignCast(@ptrCast(self.buf.ptr + format_list_limit));
     }
+    pub fn getScreens(self: @This(), allocator: std.mem.Allocator) ![]align(4) *Screen {
+        const format_list_offset = ConnectSetup.getFormatListOffset(self.fixed().vendor_len);
+        const format_list_limit = ConnectSetup.getFormatListLimit(format_list_offset, self.fixed().format_count);
+
+        const screen_count = self.fixed().root_screen_count;
+        var screens = try allocator.alloc(*Screen, screen_count);
+        var pointer_offset = format_list_limit;
+        for (0..screen_count) |screen_index| {
+            var screen: *align(4) Screen = @alignCast(@ptrCast(self.buf.ptr + pointer_offset));
+            screens[screen_index] = screen;
+            const depths = try screen.getAllowedDepths(allocator);
+            for (depths) |depth| {
+                pointer_offset += @sizeOf(ScreenDepth) + (@sizeOf(VisualType) * depth.visual_type_count);
+            }
+            pointer_offset += @sizeOf(Screen);
+        }
+
+        return screens;
+    }
 };
+
+var TEST_RECEIVED_CONNECT_SETUP_BUFFER align(4) = [_]u8{
+    0x90, 0xa5, 0xb8, 0x00, 0x00, 0x00, 0xa0, 0x17, 0xff, 0xff, 0x1f, 0x00, 0x00, 0x01, 0x00, 0x00, 0x14, 0x00, 0xff, 0xff, 0x02, 0x04, 0x00, 0x00, 0x20, 0x20, 0x08, 0xff, 0x00, 0x00, 0x00, 0x00, 0x54, 0x68, 0x65, 0x20, 0x58, 0x2e, 0x4f, 0x72, 0x67, 0x20, 0x46, 0x6f, 0x75, 0x6e, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x01, 0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x08, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0xb3, 0x07, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3f, 0x80, 0xfa, 0x00, 0x00, 0x0f, 0x70, 0x08, 0xf7, 0x03, 0x3b, 0x02, 0x01, 0x00, 0x01, 0x00, 0x21, 0x00, 0x00, 0x00, 0x01, 0x00, 0x18, 0x04, 0x01, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x93, 0x06, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9a, 0x07, 0x00, 0x00, 0x05, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7c, 0x00, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9b, 0x07, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xb1, 0x07, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xb4, 0x07, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3f, 0x80, 0xfa, 0x00, 0x80, 0x07, 0x38, 0x04, 0xf7, 0x03, 0x3b, 0x02, 0x01, 0x00, 0x01, 0x00, 0x21, 0x00, 0x00, 0x00, 0x01, 0x00, 0x18, 0x04, 0x01, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x00, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x93, 0x06, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9a, 0x07, 0x00, 0x00, 0x05, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7c, 0x00, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x9b, 0x07, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xb1, 0x07, 0x00, 0x00, 0x04, 0x08, 0x00, 0x01, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+test "Parse received ConnectSetup message" {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const connect_setup_stub = ConnectSetup {
+        .buf = TEST_RECEIVED_CONNECT_SETUP_BUFFER[0..],
+    };
+    // We avoid de-initializing to keep the test buffer around for other tests
+    //defer connect_setup_stub.deinit(allocator);
+
+    // Check the fixed part of the header
+    // -------------------------------------------
+    const fixed = connect_setup_stub.fixed();
+    try testing.expectEqual(@as(u32, 12101008), fixed.release_number);
+    try testing.expectEqual(@as(u32, 396361728), fixed.resource_id_base);
+    try testing.expectEqual(@as(u32, 2097151), fixed.resource_id_mask);
+    try testing.expectEqual(@as(u32, 256), fixed.motion_buffer_size);
+    try testing.expectEqual(@as(u16, 20), fixed.vendor_len);
+    try testing.expectEqual(@as(u16, 65535), fixed.max_request_len);
+    try testing.expectEqual(@as(u8, 2), fixed.root_screen_count);
+    try testing.expectEqual(@as(u8, 4), fixed.format_count);
+    try testing.expectEqual(NonExhaustive(ImageByteOrder).lsb_first, fixed.image_byte_order);
+    try testing.expectEqual(@as(u8, 0), fixed.bitmap_format_bit_order);
+    try testing.expectEqual(@as(u8, 32), fixed.bitmap_format_scanline_unit);
+    try testing.expectEqual(@as(u8, 32), fixed.bitmap_format_scanline_pad);
+    try testing.expectEqual(@as(u8, 8), fixed.min_keycode);
+    try testing.expectEqual(@as(u8, 255), fixed.max_keycode);
+    try testing.expectEqual(@as(u32, 0), fixed.unused);
+    try testing.expectEqualSlices(u8, "The X.Org Foundation", try connect_setup_stub.getVendorSlice(fixed.vendor_len));
+
+    // Check over the screens
+    // -------------------------------------------
+    var screens = try connect_setup_stub.getScreens(allocator);
+    try testing.expectEqual(@as(usize, fixed.root_screen_count), screens.len);
+
+    // Check the first screen
+    try testing.expectEqual(@as(u32, 1971), screens[0].root);
+    try testing.expectEqual(@as(u32, 32), screens[0].colormap);
+    try testing.expectEqual(@as(u32, 0xffffff), screens[0].white_pixel);
+    try testing.expectEqual(@as(u32, 0x000000), screens[0].black_pixel);
+    try testing.expectEqual(@as(u32, 16416831), screens[0].input_masks);
+    try testing.expectEqual(@as(u16, 3840), screens[0].pixel_width);
+    try testing.expectEqual(@as(u16, 2160), screens[0].pixel_height);
+    try testing.expectEqual(@as(u16, 1015), screens[0].mm_width);
+    try testing.expectEqual(@as(u16, 571), screens[0].mm_height);
+    try testing.expectEqual(@as(u16, 1), screens[0].min_installed_maps);
+    try testing.expectEqual(@as(u16, 1), screens[0].max_installed_maps);
+    try testing.expectEqual(@as(u32, 33), screens[0].root_visual);
+    try testing.expectEqual(@as(u8, 1), screens[0].backing_stores);
+    try testing.expectEqual(@as(u8, 0), screens[0].save_unders);
+    try testing.expectEqual(@as(u8, 24), screens[0].root_depth);
+    try testing.expectEqual(@as(u8, 4), screens[0].allowed_depth_count);
+
+    // Quick sanity of the second screen with the fields that are different from the first screen
+    try testing.expectEqual(@as(u32, 1972), screens[1].root);
+    try testing.expectEqual(@as(u16, 1920), screens[1].pixel_width);
+    try testing.expectEqual(@as(u16, 1080), screens[1].pixel_height);
+
+    // Check over the screen depths
+    // (the depths and visual types are the same across both screens for ease of asserting during the tests)
+    // -------------------------------------------
+    for (screens) |screen| {
+        const screen_depths = try screen.getAllowedDepths(allocator);
+        try testing.expectEqual(@as(usize, screens[0].allowed_depth_count), screen_depths.len);
+
+        try testing.expectEqual(@as(u8, 1), screen_depths[0].depth);
+        try testing.expectEqual(@as(u8, 0), screen_depths[0].unused0);
+        try testing.expectEqual(@as(u16, 3), screen_depths[0].visual_type_count);
+        try testing.expectEqual(@as(u32, 0), screen_depths[0].unused1);
+
+        try testing.expectEqual(@as(u8, 4), screen_depths[1].depth);
+        try testing.expectEqual(@as(u8, 0), screen_depths[1].unused0);
+        try testing.expectEqual(@as(u16, 3), screen_depths[1].visual_type_count);
+        try testing.expectEqual(@as(u32, 0), screen_depths[1].unused1);
+
+        try testing.expectEqual(@as(u8, 24), screen_depths[2].depth);
+        try testing.expectEqual(@as(u8, 0), screen_depths[2].unused0);
+        try testing.expectEqual(@as(u16, 3), screen_depths[2].visual_type_count);
+        try testing.expectEqual(@as(u32, 0), screen_depths[2].unused1);
+
+        try testing.expectEqual(@as(u8, 32), screen_depths[3].depth);
+        try testing.expectEqual(@as(u8, 0), screen_depths[3].unused0);
+        try testing.expectEqual(@as(u16, 3), screen_depths[3].visual_type_count);
+        try testing.expectEqual(@as(u32, 0), screen_depths[3].unused1);
+
+        for (screen_depths) |screen_depth| {
+            // Check over the visual types
+            // -------------------------------------------
+            const visual_types = screen_depth.getVisualTypes();
+            try testing.expectEqual(@as(usize, screen_depth.visual_type_count), visual_types.len);
+            
+            switch (screen_depth.depth) {
+                1, 4 => {
+                    for (visual_types) |visual_type| {
+                        try testing.expectEqual(@as(u32, 0), visual_type.id);
+                        try testing.expectEqual(VisualType.Class.static_gray, visual_type.class);
+                        try testing.expectEqual(@as(u8, 0), visual_type.bits_per_rgb_value);
+                        try testing.expectEqual(@as(u16, 0), visual_type.colormap_entries);
+                        try testing.expectEqual(@as(u32, 0), visual_type.red_mask);
+                        try testing.expectEqual(@as(u32, 0), visual_type.green_mask);
+                        try testing.expectEqual(@as(u32, 0), visual_type.blue_mask);
+                        try testing.expectEqual(@as(u32, 0), visual_type.unused);
+                    }
+                },
+                24 => {
+                    try testing.expectEqual(@as(u32, 33), visual_types[0].id);
+                    try testing.expectEqual(VisualType.Class.true_color, visual_types[0].class);
+                    try testing.expectEqual(@as(u8, 8), visual_types[0].bits_per_rgb_value);
+                    try testing.expectEqual(@as(u16, 256), visual_types[0].colormap_entries);
+                    try testing.expectEqual(@as(u32, 0xff0000), visual_types[0].red_mask);
+                    try testing.expectEqual(@as(u32, 0x00ff00), visual_types[0].green_mask);
+                    try testing.expectEqual(@as(u32, 0x0000ff), visual_types[0].blue_mask);
+                    try testing.expectEqual(@as(u32, 0), visual_types[0].unused);
+
+                    try testing.expectEqual(@as(u32, 1683), visual_types[1].id);
+
+                    try testing.expectEqual(@as(u32, 1946), visual_types[2].id);
+                    try testing.expectEqual(VisualType.Class.direct_color, visual_types[2].class);
+                },
+                32 => {
+                    try testing.expectEqual(@as(u32, 124), visual_types[0].id);
+                    try testing.expectEqual(VisualType.Class.true_color, visual_types[0].class);
+                    try testing.expectEqual(@as(u8, 8), visual_types[0].bits_per_rgb_value);
+                    try testing.expectEqual(@as(u16, 256), visual_types[0].colormap_entries);
+                    try testing.expectEqual(@as(u32, 0xff0000), visual_types[0].red_mask);
+                    try testing.expectEqual(@as(u32, 0x00ff00), visual_types[0].green_mask);
+                    try testing.expectEqual(@as(u32, 0x0000ff), visual_types[0].blue_mask);
+                    try testing.expectEqual(@as(u32, 0), visual_types[0].unused);
+
+                    try testing.expectEqual(@as(u32, 1947), visual_types[1].id);
+
+                    try testing.expectEqual(@as(u32, 1969), visual_types[2].id);
+                },
+                else => unreachable,
+            }
+        }
+    }
+}
 
 pub fn rgb24To16(color: u24) u16 {
     const r: u16 = @intCast((color >> 19) & 0x1f);


### PR DESCRIPTION
Parse the rest of the connection setup buffer to get the screens, depths, and visual types

This is one step on the path towards making the window transparent. Even though you can use `0xAARRGGBB` colors, the alpha channel has no effect when using the 24-bit color depth that gets inherited from the root window by default.

If you naively, only set `create_window.Args.depth = 32`, you get a `ErrorCode.match` error when creating the window.

So I think we need to also set the matching visual type ID that has the correct `depth` and `.true_color` and use it when creating the window. Albeit, you still get a `ErrorCode.match` error at this point.

Judging from the conversation on [this StackOverflow question](https://stackoverflow.com/a/3646456/796832), I think another piece is figuring out what colormap to set on `window.Options.colormap` but I can tackle this in another follow-up PR if necessary.

---

Feel free to nit whatever :bow:. I'm new to Zig and X11 development so there is bound to be better patterns to accomplish some of these things.


### Dev notes

*(source https://www.x.org/releases/current/doc/xproto/x11protocol.html#Encoding::Connection_Setup)*

<details>
<summary>Connection setup buffer format</summary>

```
     1     1                               Success
     1                                     unused
     2     CARD16                          protocol-major-version
     2     CARD16                          protocol-minor-version
     2     8+2n+(v+p+m)/4                  length in 4-byte units of
                                           "additional data"
     4     CARD32                          release-number
     4     CARD32                          resource-id-base
     4     CARD32                          resource-id-mask
     4     CARD32                          motion-buffer-size
     2     v                               length of vendor
     2     CARD16                          maximum-request-length
     1     CARD8                           number of SCREENs in roots
     1     n                               number for FORMATs in
                                           pixmap-formats
     1                                     image-byte-order
          0     LSBFirst
          1     MSBFirst
     1                                     bitmap-format-bit-order
          0     LeastSignificant
          1     MostSignificant
     1     CARD8                           bitmap-format-scanline-unit
     1     CARD8                           bitmap-format-scanline-pad
     1     KEYCODE                         min-keycode
     1     KEYCODE                         max-keycode
     4                                     unused
     v     STRING8                         vendor
     p                                     unused, p=pad(v)
     8n     LISTofFORMAT                   pixmap-formats
     m     LISTofSCREEN                    roots (m is always a multiple of 4)
FORMAT
     1     CARD8                           depth
     1     CARD8                           bits-per-pixel
     1     CARD8                           scanline-pad
     5                                     unused
SCREEN
     4     WINDOW                          root
     4     COLORMAP                        default-colormap
     4     CARD32                          white-pixel
     4     CARD32                          black-pixel
     4     SETofEVENT                      current-input-masks
     2     CARD16                          width-in-pixels
     2     CARD16                          height-in-pixels
     2     CARD16                          width-in-millimeters
     2     CARD16                          height-in-millimeters
     2     CARD16                          min-installed-maps
     2     CARD16                          max-installed-maps
     4     VISUALID                        root-visual
     1                                     backing-stores
          0     Never
          1     WhenMapped
          2     Always
     1     BOOL                            save-unders
     1     CARD8                           root-depth
     1     CARD8                           number of DEPTHs in allowed-depths
     n     LISTofDEPTH                     allowed-depths (n is always a
                                           multiple of 4)
DEPTH
     1     CARD8                           depth
     1                                     unused
     2     n                               number of VISUALTYPES in visuals
     4                                     unused
     24n     LISTofVISUALTYPE              visuals
VISUALTYPE
     4     VISUALID                        visual-id
     1                                     class
          0     StaticGray
          1     GrayScale
          2     StaticColor
          3     PseudoColor
          4     TrueColor
          5     DirectColor
     1     CARD8                           bits-per-rgb-value
     2     CARD16                          colormap-entries
     4     CARD32                          red-mask
     4     CARD32                          green-mask
     4     CARD32                          blue-mask
     4                                     unused
```

</details>

The nested flexible array members (variable length array) of screens, depths, and visual types make the pointer arithmetic a bit more hairy than desired.