### PR TITLE
Use matching window ID

### DIFF
--- a/example.zig
+++ b/example.zig
@@ -87,7 +87,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = bg_gc_id,
-            .drawable_id = screen.root,
+            .drawable_id = window_id,
         }, .{
             .foreground = screen.black_pixel,
         });
@@ -98,7 +98,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = fg_gc_id,
-            .drawable_id = screen.root,
+            .drawable_id = window_id,
         }, .{
             .background = screen.black_pixel,
             .foreground = 0xffaadd,

--- a/fontviewer.zig
+++ b/fontviewer.zig
@@ -108,7 +108,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = ids.gcBackground(),
-            .drawable_id = screen.root,
+            .drawable_id = ids.window(),
         }, .{
             .background = 0xffffff,
             .foreground = 0xffffff,
@@ -120,7 +120,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = ids.gcText(),
-            .drawable_id = screen.root,
+            .drawable_id = ids.window(),
         }, .{
             .background = 0xffffff,
             .foreground = 0,

--- a/graphics.zig
+++ b/graphics.zig
@@ -87,7 +87,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = bg_gc_id,
-            .drawable_id = screen.root,
+            .drawable_id = window_id,
         }, .{
             .foreground = screen.black_pixel,
         });
@@ -98,7 +98,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = fg_gc_id,
-            .drawable_id = screen.root,
+            .drawable_id = window_id,
         }, .{
             .background = screen.black_pixel,
             .foreground = 0xffaadd,

--- a/input.zig
+++ b/input.zig
@@ -132,7 +132,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = bg_gc_id,
-            .drawable_id = screen.root,
+            .drawable_id = window_id,
         }, .{
             .foreground = fg_color,
         });
@@ -142,7 +142,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = fg_gc_id,
-            .drawable_id = screen.root,
+            .drawable_id = window_id,
         }, .{
             .background = bg_color,
             .foreground = fg_color,

--- a/testexample.zig
+++ b/testexample.zig
@@ -154,7 +154,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = ids.bg_gc(),
-            .drawable_id = screen.root,
+            .drawable_id = ids.window(),
         }, .{
             .foreground = screen.black_pixel,
         });
@@ -164,7 +164,7 @@ pub fn main() !u8 {
         var msg_buf: [x.create_gc.max_len]u8 = undefined;
         const len = x.create_gc.serialize(&msg_buf, .{
             .gc_id = ids.fg_gc(),
-            .drawable_id = screen.root,
+            .drawable_id = ids.window(),
         }, .{
             .background = screen.black_pixel,
             .foreground = x.rgb24To(0xffaadd, screen.root_depth),


### PR DESCRIPTION
Use matching window ID

The examples work just fine currently but I thought I would fix this foot-gun for anyone trying to adapt them with modified properties like using 32-bit color depth.

This avoids `match` errors like the following when you move away from inheriting everything from the root window:
```zig
x.ServerMsg.Error{
    .reponse_type = x.ErrorKind.err,
    .code = x.ErrorCode.match,
    .sequence = 7,
    .generic = 436207617,
    .minor_opcode = 0,
    .major_opcode = x.Opcode.poly_fill_rectangle,
    .data = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
}
```

Real-world example: https://github.com/MadLittleMods/fps-aim-analyzer/pull/2