### PR TITLE
Expand X Input extension so you can listen to raw mouse/keyboard events

### DIFF
--- a/x.zig
+++ b/x.zig
@@ -1854,6 +1854,8 @@ pub const EventCode = enum(u8) {
 
 pub const ErrorKind = enum(u8) { err = 0 };
 pub const ReplyKind = enum(u8) { reply = 1 };
+// From the X Generic Event Extension
+pub const GenericEventKind = enum(u8) { generic_extension_event = 35 };
 pub const ServerMsgKind = enum(u8) {
     err = @intFromEnum(ErrorKind.err),
     reply = @intFromEnum(ReplyKind.reply),
@@ -1890,6 +1892,7 @@ pub const ServerMsgKind = enum(u8) {
     colormap_notify   = @intFromEnum(EventCode.colormap_notify),
     client_message    = @intFromEnum(EventCode.client_message),
     mapping_notify    = @intFromEnum(EventCode.mapping_notify),
+    generic_extension_event        = @intFromEnum(GenericEventKind.generic_extension_event),
     _,
 };
 
@@ -1911,6 +1914,7 @@ pub const ServerMsgTaggedUnion = union(enum) {
     reparent_notify: *align(4) Event.ReparentNotify,
     configure_notify: *align(4) Event.ConfigureNotify,
     mapping_notify: *align(4) Event.MappingNotify,
+    generic_extension_event: *align(4) ServerMsg.GenericExtensionEvent,
 };
 pub fn serverMsgTaggedUnion(msg_ptr: [*]align(4) u8) ServerMsgTaggedUnion {
     switch (@as(ServerMsgKind, @enumFromInt(0x7f & msg_ptr[0]))) {
@@ -1930,6 +1934,7 @@ pub fn serverMsgTaggedUnion(msg_ptr: [*]align(4) u8) ServerMsgTaggedUnion {
         .reparent_notify => return .{ .reparent_notify = @ptrCast(msg_ptr) },
         .configure_notify => return .{ .configure_notify = @ptrCast(msg_ptr) },
         .mapping_notify => return .{ .mapping_notify = @ptrCast(msg_ptr) },
+        .generic_extension_event => return .{ .generic_extension_event = @ptrCast(msg_ptr) },
         else => return .{ .unhandled = @ptrCast(msg_ptr) },
     }
 }
@@ -1939,6 +1944,7 @@ pub const ServerMsg = extern union {
     generic: Generic,
     err: Error,
     reply: Reply,
+    generic_extension_event: GenericExtensionEvent,
     query_font: QueryFont,
     query_text_extents: QueryTextExtents,
     list_fonts: ListFonts,
@@ -1959,6 +1965,20 @@ pub const ServerMsg = extern union {
         reserve_min: [24]u8,
     };
     comptime { std.debug.assert(@sizeOf(Reply) == 32); }
+
+    // From the X Generic Event Extension
+    pub const GenericExtensionEvent = extern struct {
+        response_type: GenericEventKind,
+        /// The major opcode of the extension.
+        ext_opcode: u8,
+        sequence: u16,
+        /// The length field specifies the number of 4-byte blocks after the
+        /// initial 32 bytes. If length is 0, the event is 32 bytes long.
+        word_len: u32, // length in 4-byte words
+        event_opcode: u16,
+        reserve_min: [22]u8,
+    };
+    comptime { std.debug.assert(@sizeOf(GenericExtensionEvent) == 32); }
 
     comptime { std.debug.assert(@sizeOf(Error) == 32); }
     pub const Error = extern struct {
@@ -2288,13 +2308,26 @@ pub const StringListIterator = struct {
     }
 };
 
+/// Given the first 32 bytes of a given message coming across the wire,
+/// parse out the given type and return the number of bytes that should be in the message
 pub fn parseMsgLen(buf: [32]u8) u32 {
     switch (buf[0] & 0x7f) {
         @intFromEnum(ServerMsgKind.err) => return 32,
-        @intFromEnum(ServerMsgKind.reply) =>
-            return 32 + (4 * readIntNative(u32, buf[4..8])),
+        @intFromEnum(ServerMsgKind.reply),
+        @intFromEnum(ServerMsgKind.generic_extension_event) => {
+            // Here is how those `4` and `8` magic numbers offsets are derived:
+            // const start_offset = @offsetOf(ServerMsg.Reply, "word_len");
+            // const end_offset = start_offset + @sizeOf(std.meta.FieldType(ServerMsg.Reply, .word_len));
+            //
+            // Or in the case of the generic extension event:
+            // const start_offset = @offsetOf(ServerMsg.GenericExtensionEvent, "word_len");
+            // const end_offset = start_offset + @sizeOf(std.meta.FieldType(ServerMsg.GenericExtensionEvent, .word_len));
+            //
+            const calculated_msg_length = 32 + (4 * readIntNative(u32, buf[4..8]));
+            return calculated_msg_length;
+        },
         2 ... 34 => return 32,
-        else => |t| std.debug.panic("handle reply type {}", .{t}),
+        else => |t| std.debug.panic("We currently do not handle reply type {}", .{t}),
     }
 }
 

--- a/xinputext.zig
+++ b/xinputext.zig
@@ -31,9 +31,90 @@ pub const ExtOpcode = enum(u8) {
     get_device_key_mapping = 24,
     change_device_key_mapping = 25,
     get_device_modifier_mapping = 26,
+    select_events = 46,
+    query_version = 47,
     change_property = 57,
     get_property = 59,
 };
+
+pub const ExtEventCode = enum(u8) {
+    device_changed = 1,
+    key_press = 2,
+    key_release = 3,
+    button_press = 4,
+    button_release = 5,
+    motion = 6,
+    enter = 7,
+    leave = 8,
+    focus_in = 9,
+    focus_out = 10,
+    hierarchy = 11,
+    property = 12,
+    raw_key_press = 13,
+    raw_key_release = 14,
+    raw_button_press = 15,
+    raw_button_release = 16,
+    raw_motion = 17,
+    touch_begin = 18,
+    touch_update = 19,
+    touch_end = 20,
+    touch_ownership = 21,
+    raw_touch_begin = 22,
+    raw_touch_update = 23,
+    raw_touch_end = 24,
+    barrier_hit = 25,
+    barrier_leave = 26,
+    gesture_pinch_begin = 27,
+    gesture_pinch_update = 28,
+    gesture_pinch_end = 29,
+    gesture_swipe_begin = 30,
+    gesture_swipe_update = 31,
+    gesture_swipe_end = 32,
+};
+
+// Abbreviated as `FP3232` in X Input extension protocol documentation.
+pub const fixed_point_32_32 = extern struct {
+    integral: i32,
+    fractional: u32,
+};
+
+pub const ExtEvent = struct {
+    pub const RawButtonPress = extern struct {
+        response_type: x.GenericEventKind,
+        /// The major opcode of the extension.
+        ext_opcode: u8,
+        sequence: u16,
+        /// The length field specifies the number of 4-byte blocks after the
+        /// initial 32 bytes. If length is 0, the event is 32 bytes long.
+        word_len: u32, // length in 4-byte words
+        event_opcode: u16,
+        device_id: u16,
+        timestamp: u32,
+
+        detail: u32,
+        source_device_id: u16,
+        valuators_len: u16,
+        pointer_event_flags: u32,
+        // TODO: Handle the rest
+        // unused2: u32, // padding
+        // valuators_mask: u32,
+        // axis_values: fixed_point_32_32,
+        // axis_values_raw: fixed_point_32_32,
+    };
+};
+
+pub const GenericExtensionEventTaggedUnion = union(enum) {
+    unhandled: *align(4) x.ServerMsg.GenericExtensionEvent,
+    raw_button_press: *align(4) ExtEvent.RawButtonPress,
+};
+
+pub fn genericExtensionEventTaggedUnion(msg_ptr: [*]align(4) u8) GenericExtensionEventTaggedUnion {
+    // `msg_ptr[8]` points at the `event_opcode` part of the event.
+    switch (@as(ExtEventCode, @enumFromInt(0x7f & msg_ptr[8]))) {
+        .raw_button_press => return .{ .raw_button_press = @ptrCast(msg_ptr) },
+        else => return .{ .unhandled = @ptrCast(msg_ptr) },
+    }
+}
 
 pub const get_extension_version = struct {
     pub const non_list_len =
@@ -61,6 +142,53 @@ pub const get_extension_version = struct {
         buf[6] = 0; // unused
         buf[7] = 0; // unused
     }
+    pub const Reply = extern struct {
+        response_type: x.ReplyKind,
+        unused_pad: u8,
+        sequence: u16,
+        word_len: u32,
+        // The `xi_reply_type` field is listed in the XCB XML protocol definitions but I
+        // don't see it in actual scenarios. It's also not part of the `libxi` ->
+        // `xGetExtensionVersionReply` definition.
+        //
+        //xi_reply_type: u8,
+        major_version: u16,
+        minor_version: u16,
+        present: bool,
+        reserved: [19]u8,
+    };
+    comptime { std.debug.assert(@sizeOf(Reply) == 32); }
+};
+
+pub const query_version = struct {
+    pub const len =
+              2 // extension and command opcodes
+            + 2 // request length
+            + 2 // client major version
+            + 2 // client minor version
+    ;
+    pub const Args = struct {
+        major_version: u16,
+        minor_version: u16,
+    };
+    pub fn serialize(buf: [*]u8, ext_opcode: u8, args: Args) void {
+        buf[0] = ext_opcode;
+        buf[1] = @intFromEnum(ExtOpcode.query_version);
+        std.debug.assert(len & 0x3 == 0);
+        x.writeIntNative(u16, buf + 2, len >> 2);
+        x.writeIntNative(u16, buf + 4, args.major_version);
+        x.writeIntNative(u16, buf + 6, args.minor_version);
+    }
+    pub const Reply = extern struct {
+        response_type: x.ReplyKind,
+        unused_pad: u8,
+        sequence: u16,
+        word_len: u32,
+        major_version: u16,
+        minor_version: u16,
+        reserved: [20]u8,
+    };
+    comptime { std.debug.assert(@sizeOf(Reply) == 32); }
 };
 
 pub const list_input_devices = struct {
@@ -331,3 +459,102 @@ pub const ListInputDevicesReply = extern struct {
     }
 };
 comptime { std.debug.assert(@sizeOf(ListInputDevicesReply) == 32); }
+
+pub const event = struct {
+    pub const device_changed: u32 = (1 << 1);
+    pub const key_press: u32 = (1 << 2);
+    pub const key_release: u32 = (1 << 3);
+    pub const button_press: u32 = (1 << 4);
+    pub const button_release: u32 = (1 << 5);
+    pub const motion: u32 = (1 << 6);
+    pub const enter: u32 = (1 << 7);
+    pub const leave: u32 = (1 << 8);
+    pub const focus_in: u32 = (1 << 9);
+    pub const focus_out: u32 = (1 << 10);
+    pub const hierarchy: u32 = (1 << 11);
+    pub const property: u32 = (1 << 12);
+    // Events (v2.1)
+    pub const raw_key_press: u32 = (1 << 13);
+    pub const raw_key_release: u32 = (1 << 14);
+    pub const raw_button_press: u32 = (1 << 15);
+    pub const raw_button_release: u32 = (1 << 16);
+    pub const raw_motion: u32 = (1 << 17);
+    // Events (v2.2)
+    pub const touch_begin: u32 = (1 << 18);
+    pub const touch_update: u32 = (1 << 19);
+    pub const touch_end: u32 = (1 << 20);
+    pub const touch_ownership: u32 = (1 << 21);
+    pub const raw_touch_begin: u32 = (1 << 22);
+    pub const raw_touch_update: u32 = (1 << 23);
+    pub const raw_touch_end: u32 = (1 << 24);
+    // Events (v2.3)
+    pub const barrier_hit: u32 = (1 << 25);
+    pub const barrier_leave: u32 = (1 << 26);
+};
+
+pub const Device = enum(u16) {
+    all = 0,
+    all_master = 1,
+};
+
+pub const EventMask = struct {
+    device_id: x.NonExhaustive(Device),
+    /// Bit mask made up of `x.inputext.event.*` constants that you're interested in.
+    /// ex. `x.inputext.event.raw_button_press | x.inputext.event.raw_key_release`
+    mask: u32,
+};
+
+/// Specify which X Input events this window is interested in.
+pub const select_events = struct {
+    const size_of_event_mask_over_the_wire =
+          2 // device_id
+        + 2 // mask_len
+        + 4 // mask
+    ;
+    comptime { std.debug.assert(size_of_event_mask_over_the_wire == 8); }
+
+    pub const non_option_len =
+              2 // extension and command opcodes
+              + 2 // request length
+              + 4 // window_id
+              + 2 // num_mask
+              + 2 // padding
+    ;
+    comptime { std.debug.assert(non_option_len == 12); }
+
+    pub fn getLen(num_masks: u16) u16 {
+        return non_option_len +
+            (size_of_event_mask_over_the_wire * num_masks);
+    }
+
+    pub const Args = struct {
+        window_id: u32,
+        masks: []EventMask,
+    };
+    pub fn serialize(buf: [*]u8, ext_opcode: u8, args: Args) u16 {
+        buf[0] = ext_opcode;
+        buf[1] = @intFromEnum(ExtOpcode.select_events);
+        const calculated_length = getLen(@as(u16, @intCast(args.masks.len)));
+        x.writeIntNative(u16, buf + 2, calculated_length >> 2);
+        x.writeIntNative(u32, buf + 4, args.window_id);
+        x.writeIntNative(u16, buf + 8, @as(u16, @intCast(args.masks.len)));
+        // 2 bytes of padding
+
+        var current_request_len: u16 = non_option_len;
+
+        // Length of mask in 4 byte units. Since our masks are always u32, this is always 1.
+        const mask_len: u16 = @sizeOf(u32) / 4;
+        for (args.masks) |mask| {
+            x.writeIntNative(u16, buf + current_request_len, @intFromEnum(mask.device_id));
+            x.writeIntNative(u16, buf + current_request_len + 2, mask_len);
+            x.writeIntNative(u32, buf + current_request_len + 4, mask.mask);
+
+            current_request_len += size_of_event_mask_over_the_wire;
+        }
+
+        // Quick sanity check that are assembled length is the same as the length we calculated.
+        std.debug.assert(current_request_len == calculated_length);
+
+        return current_request_len;
+    }
+};


### PR DESCRIPTION
Expand X Input extension so you can listen to raw mouse/keyboard events. 

Adds to the X Input extension `xinputext.zig`:

 - `select_events`
 
 
#### Why?

With the normal `.event_mask` when you create a window, you can only detect mouse clicks directly on your own window. With the raw events from the X Input extension, you can detect clicks on any window regardless of if you have focus.
 
 
### Testing strategy

 1. Start the example program:
    ```sh
    $ zig run input.zig
    ```
 1. Hit `L` to start listening to raw mouse clicks
 1. Click around outside of the window and notice the log output:
    ```
    info: TODO: handle a raw_button_press xinputext.ExtEvent.RawButtonPress{ .response_type = x.GenericEventKind.generic_extension_event, .ext_opcode = 131, .sequence = 1629, .word_len = 2, .event_opcode = 15, .device_id = 2, .timestamp = 3603091599, .detail = 1, .source_device_id = 9, .valuators_len = 2, .pointer_event_flags = 0 }
    ```

![](https://github.com/marler8997/zigx/assets/558581/0c01b938-eded-4692-8567-dcda7d77d7dd)


### Dev notes

Real world example: https://github.com/MadLittleMods/fps-aim-analyzer/pull/6

X Input extension:

 - The X Input Extension protocol docs:
    - https://www.x.org/releases/X11R7.7/doc/inputproto/XI2proto.txt
 - XML definitions of the protocol: https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/1388374c7149114888a6a5cd6e9bf6ad4b42adf8/src/xinput.xml
 - C library: https://gitlab.freedesktop.org/xorg/lib/libxi

