### PR TITLE
Add X Shape extension (`rectangles`)

### DIFF
--- a/src/x.zig
+++ b/src/x.zig
@@ -35,6 +35,7 @@ const windows = std.os.windows;
 pub const inputext = @import("xinputext.zig");
 pub const render = @import("xrender.zig");
 pub const dbe = @import("xdbe.zig");
+pub const shape = @import("xshape.zig");
 pub const testext = @import("xtest.zig");
 
 // Expose some helpful stuff
@@ -1749,12 +1750,13 @@ pub const poly_line = struct {
     }
 };
 
-pub const Rectangle = struct {
+pub const Rectangle = extern struct {
     x: i16,
     y: i16,
     width: u16,
     height: u16,
 };
+comptime { std.debug.assert(@sizeOf(Rectangle) == 8); }
 
 const poly_rectangle_common = struct {
     pub const non_list_len =

--- a/src/xshape.zig
+++ b/src/xshape.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+
+const x = @import("x.zig");
+
+pub const ExtOpcode = enum(u8) {
+    query_version = 0,
+    rectangles = 1,
+    // mask = 2,
+    // combine = 3,
+    // offset = 4,
+    // query_extents = 5,
+    // select_input = 6,
+    // input_selected = 7,
+    // get_rectangles = 8,
+};
+
+pub const Kind = enum(u8) {
+    bounding = 0,
+    clip = 1,
+    input = 2,
+};
+
+pub const Operation = enum(u8) {
+    set = 0,
+    @"union" = 1,
+    intersect = 2,
+    subtract = 3,
+    invert = 4,
+};
+
+pub const Ordering = enum(u8) {
+    unsorted = 0,
+    y_sorted = 1,
+    yx_sorted = 2,
+    yx_banded = 3,
+};
+
+pub const query_version = struct {
+    pub const len =
+              2 // extension and command opcodes
+            + 2 // request length
+    ;
+    pub fn serialize(buf: [*]u8, ext_opcode: u8) void {
+        buf[0] = ext_opcode;
+        buf[1] = @intFromEnum(ExtOpcode.query_version);
+        x.writeIntNative(u16, buf + 2, len >> 2);
+    }
+    pub const Reply = extern struct {
+        response_type: x.ReplyKind,
+        unused_pad: u8,
+        sequence: u16,
+        word_len: u32,
+        major_version: u16,
+        minor_version: u16,
+        reserved: [20]u8,
+    };
+    comptime { std.debug.assert(@sizeOf(Reply) == 32); }
+};
+
+
+pub const rectangles = struct {
+    pub const non_list_len =
+              2 // extension and command opcodes
+            + 2 // request length
+            + 1 // operation
+            + 1 // destination kind
+            + 1 // ordering
+            + 1 // unused
+            + 4 // destination window
+            + 2 // x offset
+            + 2 // y offset
+    ;
+    pub fn getLen(number_of_rectangles: u16) u16 {
+        return non_list_len + (@sizeOf(x.Rectangle) * number_of_rectangles);
+    }
+    pub const Args = struct {
+        destination_window_id: u32,
+        destination_kind: Kind,
+        operation: Operation,
+        x_offset: i16,
+        y_offset: i16,
+        ordering: Ordering,
+        rectangles: []const x.Rectangle,
+    };
+    pub fn serialize(buf: [*]u8, ext_opcode: u8, args: Args) void {
+        buf[0] = ext_opcode;
+        buf[1] = @intFromEnum(ExtOpcode.rectangles);
+        const len = getLen(@intCast(args.rectangles.len));
+        x.writeIntNative(u16, buf + 2, len >> 2);
+        buf[4] = @intFromEnum(args.operation);
+        buf[5] = @intFromEnum(args.destination_kind);
+        buf[6] = @intFromEnum( args.ordering);
+        buf[7] = 0; // unused
+        x.writeIntNative(u32, buf + 8, args.destination_window_id);
+        x.writeIntNative(i16, buf + 12, args.x_offset);
+        x.writeIntNative(i16, buf + 14, args.y_offset);
+        var current_offset: u16 = non_list_len;
+        for (args.rectangles) |rectangle| {
+            x.writeIntNative(i16, buf + current_offset + 0, rectangle.x);
+            x.writeIntNative(i16, buf + current_offset + 2, rectangle.y);
+            x.writeIntNative(u16, buf + current_offset + 4, rectangle.width);
+            x.writeIntNative(u16, buf + current_offset + 6, rectangle.height);
+            current_offset += @sizeOf(x.Rectangle);
+        }
+    }
+};


### PR DESCRIPTION
The typical use for the X Shape extension is to allow windows to be non-rectangular or change the input shape that mouse events interact with on the window. This PR only adds support for the `rectangles` request but this still allows you to adjust the *bounding region*, *clip region*, or *input region* with rectangular shapes.

I plan to use this in order to overlay a window which shows debug markers in a [OCR (character recognition) project](https://github.com/MadLittleMods/fps-aim-analyzer/pull/8) in a video game without affecting the mouse (make the debug window pass-through all movement/click events, etc).

### Testing strategy

 1. Start the example program:
    ```sh
    $ zig run testexample.zig
    ```
 1. Notice that in the dark red area of the window that your mouse instead interacts with the windows below.

![Test example window with a dark red click-through area at the bottom](https://github.com/marler8997/zigx/assets/558581/9a098751-ec41-464f-978f-2b91a857c079)

Note: I have seen that the click-through doesn't seem to always "apply" when you spawn the window. This probably has something to do with the extra window manager/decorations and the order of operations on how all of the commands are flying over to the X server maybe.


### Dev notes

 - X Shape extension protocol docs: https://www.x.org/releases/current/doc/xextproto/shape.html
 - XML definitions of the protocol: https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/1388374c7149114888a6a5cd6e9bf6ad4b42adf8/src/shape.xml
 
Reference:

 - https://shallowsky.com/blog/programming/translucent-window-click-thru.html
 - https://stackoverflow.com/questions/16400937/click-through-transparent-xlib-windows
 - https://stackoverflow.com/questions/9046440/pygtk-window-with-box-that-ignores-all-xmouseevents-passes-them-through
  - https://stackoverflow.com/questions/4326534/x11-xlib-create-glasspane-window