### PR TITLE
Add support for X `TEST` extension to send fake click events

### DIFF
--- a/examples/common.zig
+++ b/examples/common.zig
@@ -216,7 +216,7 @@ pub const ExtensionVersion = struct {
 
 /// Determines whether the extension is available on the server.
 pub fn getExtensionInfo(
-    sock: std.os.socket_t,
+    sock: std.posix.socket_t,
     buffer: *x.ContiguousReadBuffer,
     comptime extension_name: []const u8,
 ) !?ExtensionInfo {

--- a/examples/common.zig
+++ b/examples/common.zig
@@ -4,6 +4,17 @@ const common = @This();
 
 pub const SocketReader = std.io.Reader(std.posix.socket_t, std.posix.RecvFromError, readSocket);
 
+/// Sanity check that we're not running into data integrity (corruption) issues caused
+/// by overflowing and wrapping around to the front ofq the buffer.
+fn checkMessageLengthFitsInBuffer(message_length: usize, buffer_limit: usize) !void {
+    if(message_length > buffer_limit) {
+        std.debug.panic("Reply is bigger than our buffer (data corruption will ensue) {} > {}. In order to fix, increase the buffer size.", .{
+            message_length,
+            buffer_limit,
+        });
+    }
+}
+
 pub fn send(sock: std.posix.socket_t, data: []const u8) !void {
     const sent = try x.writeSock(sock, data, 0);
     if (sent != data.len) {
@@ -185,4 +196,68 @@ pub fn asReply(comptime T: type, msg_bytes: []align(4) u8) !*T {
 
 fn readSocket(sock: std.posix.socket_t, buffer: []u8) !usize {
     return x.readSock(sock, buffer, 0);
+}
+
+/// X server extension info.
+pub const ExtensionInfo = struct {
+    extension_name: []const u8,
+    /// The extension opcode is used to identify which X extension a given request is
+    /// intended for (used as the major opcode). This essentially namespaces any extension
+    /// requests. The extension differentiates its own requests by using a minor opcode.
+    opcode: u8,
+    /// Extension error codes are added on top of this base error code.
+    base_error_code: u8,
+};
+
+pub const ExtensionVersion = struct {
+    major_version: u16,
+    minor_version: u16,
+};
+
+/// Determines whether the extension is available on the server.
+pub fn getExtensionInfo(
+    sock: std.os.socket_t,
+    buffer: *x.ContiguousReadBuffer,
+    comptime extension_name: []const u8,
+) !?ExtensionInfo {
+    const reader = common.SocketReader{ .context = sock };
+    const buffer_limit = buffer.half_len;
+
+    {
+        const ext_name = comptime x.Slice(u16, [*]const u8).initComptime(extension_name);
+        var message_buffer: [x.query_extension.getLen(ext_name.len)]u8 = undefined;
+        x.query_extension.serialize(&message_buffer, ext_name);
+        try common.send(sock, &message_buffer);
+    }
+    const message_length = try x.readOneMsg(reader, @alignCast(buffer.nextReadBuffer()));
+    try checkMessageLengthFitsInBuffer(message_length, buffer_limit);
+    const optional_extension = blk: {
+        switch (x.serverMsgTaggedUnion(@alignCast(buffer.double_buffer_ptr))) {
+            .reply => |msg_reply| {
+                const msg: *x.ServerMsg.QueryExtension = @ptrCast(msg_reply);
+                if (msg.present == 0) {
+                    std.log.info("{s} extension: not present", .{extension_name});
+                    break :blk null;
+                }
+                std.debug.assert(msg.present == 1);
+                std.log.info("{s} extension: opcode={} base_error_code={}", .{
+                    extension_name,
+                    msg.major_opcode,
+                    msg.first_error,
+                });
+                std.log.info("{s} extension: {}", .{ extension_name, msg });
+                break :blk ExtensionInfo{
+                    .extension_name = extension_name,
+                    .opcode = msg.major_opcode,
+                    .base_error_code = msg.first_error,
+                };
+            },
+            else => |msg| {
+                std.log.err("expected a reply for `x.query_extension` but got {}", .{msg});
+                return error.ExpectedReplyButGotSomethingElse;
+            },
+        }
+    };
+
+    return optional_extension;
 }

--- a/examples/testexample.zig
+++ b/examples/testexample.zig
@@ -307,33 +307,33 @@ pub fn main() !u8 {
     }
 
     // Send a fake mouse left-click event
-    if (opt_test_ext) |test_ext| {
-        {
-            var msg: [x.testext.fake_input.len]u8 = undefined;
-            x.testext.fake_input.serialize(&msg, test_ext.opcode, .{
-                .button_press = .{
-                    .event_type = x.testext.FakeEventType.button_press,
-                    .detail = 1,
-                    .delay_ms = 0,
-                    .device_id = null,
-                },
-            });
-            try conn.send(&msg);
-        }
+    // if (opt_test_ext) |test_ext| {
+    //     {
+    //         var msg: [x.testext.fake_input.len]u8 = undefined;
+    //         x.testext.fake_input.serialize(&msg, test_ext.opcode, .{
+    //             .button_press = .{
+    //                 .event_type = x.testext.FakeEventType.button_press,
+    //                 .detail = 1,
+    //                 .delay_ms = 0,
+    //                 .device_id = null,
+    //             },
+    //         });
+    //         try conn.send(&msg);
+    //     }
 
-        {
-            var msg: [x.testext.fake_input.len]u8 = undefined;
-            x.testext.fake_input.serialize(&msg, test_ext.opcode, .{
-                .button_press = .{
-                    .event_type = x.testext.FakeEventType.button_release,
-                    .detail = 1,
-                    .delay_ms = 0,
-                    .device_id = null,
-                },
-            });
-            try conn.send(&msg);
-        }
-    }
+    //     {
+    //         var msg: [x.testext.fake_input.len]u8 = undefined;
+    //         x.testext.fake_input.serialize(&msg, test_ext.opcode, .{
+    //             .button_press = .{
+    //                 .event_type = x.testext.FakeEventType.button_release,
+    //                 .detail = 1,
+    //                 .delay_ms = 0,
+    //                 .device_id = null,
+    //             },
+    //         });
+    //         try conn.send(&msg);
+    //     }
+    // }
 
     while (true) {
         {

--- a/examples/testexample.zig
+++ b/examples/testexample.zig
@@ -210,37 +210,19 @@ pub fn main() !u8 {
         }
     };
 
-    {
-        const ext_name = comptime x.Slice(u16, [*]const u8).initComptime("RENDER");
-        var msg: [x.query_extension.getLen(ext_name.len)]u8 = undefined;
-        x.query_extension.serialize(&msg, ext_name);
-        try conn.send(&msg);
-    }
-    _ = try x.readOneMsg(conn.reader(), @alignCast(buf.nextReadBuffer()));
-    const opt_render_ext: ?struct { opcode: u8 } = blk: {
-        switch (x.serverMsgTaggedUnion(@alignCast(buf.double_buffer_ptr))) {
-            .reply => |msg_reply| {
-                const msg: *x.ServerMsg.QueryExtension = @ptrCast(msg_reply);
-                if (msg.present == 0) {
-                    std.log.info("RENDER extension: not present", .{});
-                    break :blk null;
-                }
-                std.debug.assert(msg.present == 1);
-                std.log.info("RENDER extension: opcode={}", .{msg.major_opcode});
-                break :blk .{ .opcode = msg.major_opcode };
-            },
-            else => |msg| {
-                std.log.err("expected a reply but got {}", .{msg});
-                return 1;
-            },
-        }
-    };
+
+    const opt_render_ext = try common.getExtensionInfo(
+        conn.sock,
+        &buf,
+        "RENDER"
+    );
     if (opt_render_ext) |render_ext| {
+        const expected_version: common.ExtensionVersion = .{ .major_version = 0, .minor_version = 11 };
         {
             var msg: [x.render.query_version.len]u8 = undefined;
             x.render.query_version.serialize(&msg, render_ext.opcode, .{
-                .major_version = 0,
-                .minor_version = 11,
+                .major_version = expected_version.major_version,
+                .minor_version = expected_version.minor_version,
             });
             try conn.send(&msg);
         }
@@ -248,13 +230,66 @@ pub fn main() !u8 {
         switch (x.serverMsgTaggedUnion(@alignCast(buf.double_buffer_ptr))) {
             .reply => |msg_reply| {
                 const msg: *x.render.query_version.Reply = @ptrCast(msg_reply);
-                std.log.info("RENDER extension: version {}.{}", .{ msg.major_version, msg.minor_version });
-                if (msg.major_version != 0) {
-                    std.log.err("xrender extension major version {} too new", .{msg.major_version});
+                std.log.info("X RENDER extension: version {}.{}", .{msg.major_version, msg.minor_version});
+                if (msg.major_version != expected_version.major_version) {
+                    std.log.err("X RENDER extension major version is {} but we expect {}", .{
+                        msg.major_version,
+                        expected_version.major_version,
+                    });
                     return 1;
                 }
-                if (msg.minor_version < 11) {
-                    std.log.err("xrender extension minor version {} too old", .{msg.minor_version});
+                if (msg.minor_version < expected_version.minor_version) {
+                    std.log.err("X RENDER extension minor version is {}.{} but I've only tested >= {}.{})", .{
+                        msg.major_version,
+                        msg.minor_version,
+                        expected_version.major_version,
+                        expected_version.minor_version,
+                    });
+                    return 1;
+                }
+            },
+            else => |msg| {
+                std.log.err("expected a reply but got {}", .{msg});
+                return 1;
+            },
+        }
+    }
+
+    const opt_test_ext = try common.getExtensionInfo(
+        conn.sock,
+        &buf,
+        "XTEST"
+    );
+    if (opt_test_ext) |test_ext| {
+        const expected_version: common.ExtensionVersion = .{ .major_version = 2, .minor_version = 2 };
+        {
+            var msg: [x.testext.get_version.len]u8 = undefined;
+            x.testext.get_version.serialize(&msg, .{
+                .ext_opcode = test_ext.opcode,
+                .wanted_major_version = expected_version.major_version,
+                .wanted_minor_version = expected_version.minor_version,
+            });
+            try conn.send(&msg);
+        }
+        _ = try x.readOneMsg(conn.reader(), @alignCast(buf.nextReadBuffer()));
+        switch (x.serverMsgTaggedUnion(@alignCast(buf.double_buffer_ptr))) {
+            .reply => |msg_reply| {
+                const msg: *x.testext.get_version.Reply = @ptrCast(msg_reply);
+                std.log.info("XTEST extension: version {}.{}", .{msg.major_version, msg.minor_version});
+                if (msg.major_version != expected_version.major_version) {
+                    std.log.err("XTEST extension major version is {} but we expect {}", .{
+                        msg.major_version,
+                        expected_version.major_version,
+                    });
+                    return 1;
+                }
+                if (msg.minor_version < expected_version.minor_version) {
+                    std.log.err("XTEST extension minor version is {}.{} but I've only tested >= {}.{})", .{
+                        msg.major_version,
+                        msg.minor_version,
+                        expected_version.major_version,
+                        expected_version.minor_version,
+                    });
                     return 1;
                 }
             },
@@ -269,6 +304,35 @@ pub fn main() !u8 {
         var msg: [x.map_window.len]u8 = undefined;
         x.map_window.serialize(&msg, ids.window());
         try conn.send(&msg);
+    }
+
+    // Send a fake mouse left-click event
+    if (opt_test_ext) |test_ext| {
+        {
+            var msg: [x.testext.fake_input.len]u8 = undefined;
+            x.testext.fake_input.serialize(&msg, test_ext.opcode, .{
+                .button_press = .{
+                    .event_type = x.testext.FakeEventType.button_press,
+                    .detail = 1,
+                    .delay_ms = 0,
+                    .device_id = null,
+                },
+            });
+            try conn.send(&msg);
+        }
+
+        {
+            var msg: [x.testext.fake_input.len]u8 = undefined;
+            x.testext.fake_input.serialize(&msg, test_ext.opcode, .{
+                .button_press = .{
+                    .event_type = x.testext.FakeEventType.button_release,
+                    .detail = 1,
+                    .delay_ms = 0,
+                    .device_id = null,
+                },
+            });
+            try conn.send(&msg);
+        }
     }
 
     while (true) {
@@ -529,6 +593,40 @@ fn render(
             try common.send(sock, &msg);
         }
     }
+
+    // Draw a representation of the click-through area
+    {
+        try changeGcColor(sock, ids.fg_gc(), x.rgb24To(0x963b3b, depth));
+        {
+            const rectangles = [_]x.Rectangle{
+                .{ .x = 0, .y = window_height - 50, .width = window_width, .height = 50 },
+            };
+            var msg: [x.poly_fill_rectangle.getLen(rectangles.len)]u8 = undefined;
+            x.poly_fill_rectangle.serialize(&msg, .{
+                .drawable_id = ids.window(),
+                .gc_id = ids.fg_gc(),
+            }, &rectangles);
+            try common.send(sock, &msg);
+        }
+
+        try changeGcColor(sock, ids.fg_gc(), x.rgb24To(0xffaadd, depth));
+        {
+            const text_literal: []const u8 = "Click-through area!";
+            const text = x.Slice(u8, [*]const u8) { .ptr = text_literal.ptr, .len = text_literal.len };
+            var msg: [x.image_text8.getLen(text.len)]u8 = undefined;
+
+            const text_width = font_dims.width * text_literal.len;
+
+            x.image_text8.serialize(&msg, text, .{
+                .drawable_id = ids.window(),
+                .gc_id = ids.fg_gc(),
+                .x = @divTrunc((window_width - @as(i16, @intCast(text_width))),  2) + font_dims.font_left,
+                .y = window_height - 50 + @divTrunc(50 - @as(i16, @intCast(font_dims.height)), 2) + font_dims.font_ascent,
+            });
+            try common.send(sock, &msg);
+        }
+    }
+
 }
 
 fn changeGcColor(sock: std.posix.socket_t, gc_id: u32, color: u32) !void {

--- a/examples/testexample.zig
+++ b/examples/testexample.zig
@@ -593,40 +593,6 @@ fn render(
             try common.send(sock, &msg);
         }
     }
-
-    // Draw a representation of the click-through area
-    {
-        try changeGcColor(sock, ids.fg_gc(), x.rgb24To(0x963b3b, depth));
-        {
-            const rectangles = [_]x.Rectangle{
-                .{ .x = 0, .y = window_height - 50, .width = window_width, .height = 50 },
-            };
-            var msg: [x.poly_fill_rectangle.getLen(rectangles.len)]u8 = undefined;
-            x.poly_fill_rectangle.serialize(&msg, .{
-                .drawable_id = ids.window(),
-                .gc_id = ids.fg_gc(),
-            }, &rectangles);
-            try common.send(sock, &msg);
-        }
-
-        try changeGcColor(sock, ids.fg_gc(), x.rgb24To(0xffaadd, depth));
-        {
-            const text_literal: []const u8 = "Click-through area!";
-            const text = x.Slice(u8, [*]const u8) { .ptr = text_literal.ptr, .len = text_literal.len };
-            var msg: [x.image_text8.getLen(text.len)]u8 = undefined;
-
-            const text_width = font_dims.width * text_literal.len;
-
-            x.image_text8.serialize(&msg, text, .{
-                .drawable_id = ids.window(),
-                .gc_id = ids.fg_gc(),
-                .x = @divTrunc((window_width - @as(i16, @intCast(text_width))),  2) + font_dims.font_left,
-                .y = window_height - 50 + @divTrunc(50 - @as(i16, @intCast(font_dims.height)), 2) + font_dims.font_ascent,
-            });
-            try common.send(sock, &msg);
-        }
-    }
-
 }
 
 fn changeGcColor(sock: std.posix.socket_t, gc_id: u32, color: u32) !void {

--- a/src/x.zig
+++ b/src/x.zig
@@ -35,6 +35,7 @@ const windows = std.os.windows;
 pub const inputext = @import("xinputext.zig");
 pub const render = @import("xrender.zig");
 pub const dbe = @import("xdbe.zig");
+pub const testext = @import("xtest.zig");
 
 // Expose some helpful stuff
 pub const MappedFile = @import("MappedFile.zig");


### PR DESCRIPTION
Add support for X `TEST` extension to send fake click events (or keyboard events).

Useful for automating mouse/keyboard input in tests.



### Testing strategy

 1. Uncomment the lines to `// Send a fake mouse left-click event`
 1. Start the example program:
    ```sh
    $ zig run testexample.zig
    ```
 1. Notice that a left-click event is logged in the terminal and if your mouse is over top of another window, it's brought into view because it gets clicked.
 
### Dev note

 - X `TEST` extension protocol docs: https://www.x.org/releases/X11R7.7/doc/xextproto/xtest.html
 - XML definitions of the protocol: https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/blob/77d7fc04da729ddc5ed4aacf30253726fac24dca/src/xtest.xml