### PR TITLE
Fix colors in a 32-bit depth context being completely transparent

### DIFF
--- a/examples/testexample.zig
+++ b/examples/testexample.zig
@@ -577,7 +577,7 @@ fn populateTestImage(
                 32 => std.mem.writeInt(
                     u32,
                     data[data_off..][0..4],
-                    color,
+                    x.rgb24To(color, 32),
                     image_format.endian,
                 ),
                 else => std.debug.panic("TODO: implement image depth {}", .{image_format.depth}),

--- a/src/x.zig
+++ b/src/x.zig
@@ -2543,7 +2543,16 @@ pub fn rgb24To(color: u24, depth_bits: u8) u32 {
     return switch (depth_bits) {
         16 => rgb24To16(color),
         24 => color,
-        32 => color,
+        32 => {
+            // Add an opaque alpha component (0xAARRGGBB)
+            const alpha = 0xff;
+            // Shift the alpha component all the way up to the top
+            // 0x000000ff -> 0xff000000
+            const alpha_shifted: u32 = alpha << 24;
+
+            // Combine the color and alpha component
+            return alpha_shifted | color;
+        },
         else => @panic("todo"),
     };
 }


### PR DESCRIPTION
Fix colors in a 32-bit depth context being completely transparent.

Before this fix, `populateTestImage(...)` would produce completely invisible transparent images when used with 32-bit depth images. Same with the `x.rgb24To(...)` utility.

Example:

Before: `0x00777777`
After: `0xFF777777`