### PR TITLE
Consistently use x11.log instead of std.log to get .x11 log scope everywhere

### DIFF
--- a/c/x11.zig
+++ b/c/x11.zig
@@ -26,11 +26,11 @@ fn sendAll(sock: std.posix.socket_t, data: []const u8) !void {
 export fn ZigXSetErrorHandler(handler: *const fn (*anyopaque, [*:0]const u8) callconv(.c) void, ctx: *anyopaque) void {
     _ = handler;
     _ = ctx;
-    std.log.err("TODO: set error handler!", .{});
+    x11.log.err("TODO: set error handler!", .{});
 }
 fn reportErrorRaw(comptime fmt: []const u8, args: anytype) void {
     // TODO: report to handler
-    std.log.err(fmt, args);
+    x11.log.err(fmt, args);
 }
 fn reportError(comptime fmt: []const u8, args: anytype) error{Reported} {
     reportErrorRaw(fmt, args);
@@ -62,7 +62,7 @@ fn openDisplay(display_spec_opt: ?[*:0]const u8) error{ Reported, OutOfMemory }!
     // TODO: x11.getDisplay allocates on windows, maybe we cache it on windows?
     // TODO: should an empty string be handled like null as well?
     const display_spec = if (display_spec_opt) |d| std.mem.span(d) else x11.getDisplay();
-    std.log.info("connecting to DISPLAY '{s}'", .{display_spec});
+    x11.log.info("connecting to DISPLAY '{s}'", .{display_spec});
 
     const parsed_display = x11.parseDisplay(display_spec) catch |err|
         return reportError("invalid DISPLAY '{s}': {s}", .{ display_spec, @errorName(err) });
@@ -95,14 +95,14 @@ fn openDisplay(display_spec_opt: ?[*:0]const u8) error{ Reported, OutOfMemory }!
             return reportError("failed to read connect setup with {s}", .{@errorName(err)});
         switch (connect_setup_header.status) {
             .failed => {
-                std.log.debug("no auth connect setup failed, version={}.{}, reason='{f}'", .{
+                x11.log.debug("no auth connect setup failed, version={}.{}, reason='{f}'", .{
                     connect_setup_header.proto_major_ver,
                     connect_setup_header.proto_minor_ver,
                     connect_setup_header.readFailReason(reader.interface()),
                 });
             },
             .authenticate => {
-                std.log.debug("no auth connect setup failed with AUTHENTICATE", .{});
+                x11.log.debug("no auth connect setup failed with AUTHENTICATE", .{});
             },
             .success => break :blk connect_setup_header,
             else => |status| return reportError(
@@ -117,22 +117,22 @@ fn openDisplay(display_spec_opt: ?[*:0]const u8) error{ Reported, OutOfMemory }!
     defer c_allocator.free(buf);
 
     const connect_setup = x11.ConnectSetup{ .buf = buf };
-    std.log.debug("connect setup reply is {} bytes", .{connect_setup.buf.len});
+    x11.log.debug("connect setup reply is {} bytes", .{connect_setup.buf.len});
     var reader: x11.SocketReader = .init(sock);
     x11.readFull(reader.interface(), connect_setup.buf) catch |err|
         return reportError("failed to read connect setup with {s}", .{@errorName(err)});
 
     const fixed = connect_setup.fixed();
     inline for (@typeInfo(@TypeOf(fixed.*)).@"struct".fields) |field| {
-        std.log.debug("{s}: {any}", .{ field.name, @field(fixed, field.name) });
+        x11.log.debug("{s}: {any}", .{ field.name, @field(fixed, field.name) });
     }
-    //std.log.debug("vendor: {s}", .{try connect_setup.getVendorSlice(fixed.vendor_len)});
+    //x11.log.debug("vendor: {s}", .{try connect_setup.getVendorSlice(fixed.vendor_len)});
     const format_list_offset = x11.ConnectSetup.getFormatListOffset(fixed.vendor_len);
     const format_list_limit = x11.ConnectSetup.getFormatListLimit(format_list_offset, fixed.format_count);
-    std.log.debug("fmt list off={} limit={}", .{ format_list_offset, format_list_limit });
+    x11.log.debug("fmt list off={} limit={}", .{ format_list_offset, format_list_limit });
     //const formats = try connect_setup.getFormatList(format_list_offset, format_list_limit);
     //for (formats) |format, i| {
-    //    std.log.debug("format[{}] depth={:3} bpp={:3} scanpad={:3}", .{i, format.depth, format.bits_per_pixel, format.scanline_pad});
+    //    x11.log.debug("format[{}] depth={:3} bpp={:3} scanpad={:3}", .{i, format.depth, format.bits_per_pixel, format.scanline_pad});
     //}
 
     const display = try c_allocator.create(Display);
@@ -140,14 +140,14 @@ fn openDisplay(display_spec_opt: ?[*:0]const u8) error{ Reported, OutOfMemory }!
 
     const setup_screens_ptr = connect_setup.getScreensPtr(format_list_limit);
     const screens = try c_allocator.alloc(c.Screen, fixed.root_screen_count);
-    std.log.debug("screens allocated to 0x{x}", .{@intFromPtr(screens.ptr)});
+    x11.log.debug("screens allocated to 0x{x}", .{@intFromPtr(screens.ptr)});
     errdefer c_allocator.free(screens);
     for (screens, 0..) |*screen_dst, screen_index| {
         const screen_src = &setup_screens_ptr[screen_index];
         inline for (@typeInfo(@TypeOf(screen_src.*)).@"struct".fields) |field| {
-            std.log.debug("SCREEN {}| {s}: {any}", .{ screen_index, field.name, @field(screen_src, field.name) });
+            x11.log.debug("SCREEN {}| {s}: {any}", .{ screen_index, field.name, @field(screen_src, field.name) });
         }
-        std.log.debug("screen_ptr is 0x{x}", .{@intFromPtr(screen_dst)});
+        x11.log.debug("screen_ptr is 0x{x}", .{@intFromPtr(screen_dst)});
         screen_dst.* = .{
             .display = &display.public,
             .root = @intFromEnum(screen_src.root),
@@ -193,16 +193,16 @@ fn connectSetupAuth(
 
     var addr_buf: [x11.max_sock_filter_addr]u8 = undefined;
     auth_filter.applySocket(sock, &addr_buf) catch |err| {
-        std.log.warn("failed to apply socket to auth filter with {s}", .{@errorName(err)});
+        x11.log.warn("failed to apply socket to auth filter with {s}", .{@errorName(err)});
     };
 
     var auth_it = x11.AuthIterator{ .mem = auth_mapped.mem };
     while (auth_it.next() catch {
-        std.log.warn("auth file '{s}' is invalid", .{auth_filename});
+        x11.log.warn("auth file '{s}' is invalid", .{auth_filename});
         return null;
     }) |entry| {
         if (auth_filter.isFiltered(auth_mapped.mem, entry)) |reason| {
-            std.log.debug("ignoring auth because {s} does not match: {f}", .{ @tagName(reason), entry.fmt(auth_mapped.mem) });
+            x11.log.debug("ignoring auth because {s} does not match: {f}", .{ @tagName(reason), entry.fmt(auth_mapped.mem) });
             continue;
         }
         const name = entry.name(auth_mapped.mem);
@@ -231,7 +231,7 @@ fn connectSetupAuth(
             return reportError("failed to read connect setup with {s}", .{@errorName(err)});
         switch (connect_setup_header.status) {
             .failed => {
-                std.log.debug("connect setup failed, version={}.{}, reason='{f}'", .{
+                x11.log.debug("connect setup failed, version={}.{}, reason='{f}'", .{
                     connect_setup_header.proto_major_ver,
                     connect_setup_header.proto_minor_ver,
                     connect_setup_header.readFailReason(reader.interface()),
@@ -239,12 +239,12 @@ fn connectSetupAuth(
                 // try the next?
             },
             .authenticate => {
-                std.log.debug("AUTHENTICATE with {f} failed", .{entry.fmt(auth_mapped.mem)});
+                x11.log.debug("AUTHENTICATE with {f} failed", .{entry.fmt(auth_mapped.mem)});
                 // try the next auth
             },
             .success => {
                 // TODO: check version?
-                std.log.debug("SUCCESS! version {}.{}", .{ connect_setup_header.proto_major_ver, connect_setup_header.proto_minor_ver });
+                x11.log.debug("SUCCESS! version {}.{}", .{ connect_setup_header.proto_major_ver, connect_setup_header.proto_minor_ver });
                 return connect_setup_header;
             },
             else => |status| return reportError(
@@ -372,7 +372,7 @@ export fn XCreateGC(
 export fn XMapRaised(display: *c.Display, window: c.Window) c_int {
     const display_full: *Display = @fieldParentPtr("public", display);
 
-    std.log.info("TODO: send ConfigureWindow stack-mode=Above", .{});
+    x11.log.info("TODO: send ConfigureWindow stack-mode=Above", .{});
 
     var write_buf: [100]u8 = undefined;
     var socket_writer = x11.socketWriter(display.fd, &write_buf);
@@ -454,7 +454,7 @@ export fn XNextEvent(display: *c.Display, event: *c.XEvent) c_int {
     const len = x11.readOneMsg(reader.interface(), display_full.read_buf) catch |err| handleReadError(display, reader.getError(err).?);
 
     if (len > display_full.read_buf.len) {
-        std.log.err("TODO: realloc read_buf len to be bigger", .{});
+        x11.log.err("TODO: realloc read_buf len to be bigger", .{});
         //c_allocator.realloc();
         x11.readOneMsgFinish(reader.interface(), display_full.read_buf) catch |err| handleReadError(display, reader.getError(err).?);
         @panic("todo");

--- a/examples/fontviewer.zig
+++ b/examples/fontviewer.zig
@@ -58,12 +58,12 @@ pub fn mainCompat(environ: std16.process.Environ, io: std16.Io) !void {
             error.ReadFailed => return socket_reader.err.?,
             error.EndOfStream, error.Protocol => |e| return e,
         }) orelse {
-            std.log.err("no screen?", .{});
+            x11.log.err("no screen?", .{});
             std.process.exit(0xff);
         };
         const id_range = try x11.IdRange.init(setup.resource_id_base, setup.resource_id_mask);
         if (id_range.capacity() < Ids.needed_capacity) {
-            std.log.err("X server id range capacity {} is less than needed {}", .{ id_range.capacity(), Ids.needed_capacity });
+            x11.log.err("X server id range capacity {} is less than needed {}", .{ id_range.capacity(), Ids.needed_capacity });
             std.process.exit(0xff);
         }
         break :blk .{

--- a/examples/text.zig
+++ b/examples/text.zig
@@ -87,12 +87,12 @@ fn mainCompat(args_it: *ArgsIterator, environ: std16.process.Environ, io: std16.
             error.ReadFailed => return socket_reader.err.?,
             error.EndOfStream, error.Protocol => |e| return e,
         }) orelse {
-            std.log.err("no screen?", .{});
+            x11.log.err("no screen?", .{});
             std.process.exit(0xff);
         };
         const id_range = try x11.IdRange.init(setup.resource_id_base, setup.resource_id_mask);
         if (id_range.capacity() < Ids.needed_capacity) {
-            std.log.err("X server id range capacity {} is less than needed {}", .{ id_range.capacity(), Ids.needed_capacity });
+            x11.log.err("X server id range capacity {} is less than needed {}", .{ id_range.capacity(), Ids.needed_capacity });
             std.process.exit(0xff);
         }
         break :blk .{
@@ -132,12 +132,12 @@ fn run(
     opt: Options,
 ) error{ WriteFailed, ReadFailed, EndOfStream, Protocol, UnexpectedMessage }!void {
     const present_ext = try x11.draft.synchronousQueryExtension(source, sink, x11.present.name) orelse {
-        std.log.err("Present extension not available", .{});
+        x11.log.err("Present extension not available", .{});
         std.process.exit(0xff);
     };
 
     const render_ext = try x11.draft.synchronousQueryExtension(source, sink, x11.render.name) orelse {
-        std.log.err("RENDER extension not available", .{});
+        x11.log.err("RENDER extension not available", .{});
         std.process.exit(0xff);
     };
 
@@ -179,11 +179,11 @@ fn run(
         try pict_reader.discardRemaining(source);
         break :blk .{
             maybe_visual_format orelse {
-                std.log.err("no PictFormat for root visual {f}", .{root.visual});
+                x11.log.err("no PictFormat for root visual {f}", .{root.visual});
                 std.process.exit(0xff);
             },
             maybe_a8_format orelse {
-                std.log.err("no A8 PictFormat found", .{});
+                x11.log.err("no A8 PictFormat found", .{});
                 std.process.exit(0xff);
             },
         };
@@ -557,7 +557,7 @@ fn underline(
 }
 
 fn errExit(comptime fmt: []const u8, args: anytype) noreturn {
-    std.log.err(fmt, args);
+    x11.log.err(fmt, args);
     std.process.exit(0xff);
 }
 

--- a/src/x/IdRange.zig
+++ b/src/x/IdRange.zig
@@ -46,7 +46,7 @@ const is_test = @import("builtin").is_test;
 pub fn init(base: x11.ResourceBase, mask: x11.ResourceMask) error{Protocol}!IdRange {
     const mask_u32: u32 = @intFromEnum(mask);
     if (mask_u32 == 0) {
-        if (!is_test) std.log.err("X11 server provided zero resource id mask", .{});
+        if (!is_test) x11.log.err("X11 server provided zero resource id mask", .{});
         return error.Protocol;
     }
     // u5 can represent all possible values since mask_u32 is not 0 so it cannot have more than 31 0's
@@ -56,7 +56,7 @@ pub fn init(base: x11.ResourceBase, mask: x11.ResourceMask) error{Protocol}!IdRa
         // Mask must have contiguous bits: shifting out trailing zeros must yield a solid run of 1s.
         const shifted = mask_u32 >> shift;
         if (shifted & (shifted + 1) != 0) {
-            if (!is_test) std.log.err("X11 server provided non-contiguous resource id mask: 0x{x}", .{mask_u32});
+            if (!is_test) x11.log.err("X11 server provided non-contiguous resource id mask: 0x{x}", .{mask_u32});
             return error.Protocol;
         }
     }
@@ -64,23 +64,23 @@ pub fn init(base: x11.ResourceBase, mask: x11.ResourceMask) error{Protocol}!IdRa
     const bit_count: u6 = @popCount(mask_u32);
     // Per the X11 spec, the mask must contain at least 18 contiguous bits.
     if (bit_count < 18) {
-        if (!is_test) std.log.err("X11 server provided resource id mask with only {} bits (need at least 18): 0x{x}", .{ bit_count, mask_u32 });
+        if (!is_test) x11.log.err("X11 server provided resource id mask with only {} bits (need at least 18): 0x{x}", .{ bit_count, mask_u32 });
         return error.Protocol;
     }
     const base_u32: u32 = @intFromEnum(base);
     // Resource IDs never have the top three bits set.
     if ((base_u32 | mask_u32) & 0xE0000000 != 0) {
-        if (!is_test) std.log.err("X11 server provided resource ids with top 3 bits set (base=0x{x}, mask=0x{x})", .{ base_u32, mask_u32 });
+        if (!is_test) x11.log.err("X11 server provided resource ids with top 3 bits set (base=0x{x}, mask=0x{x})", .{ base_u32, mask_u32 });
         return error.Protocol;
     }
     // Base can't be 0 since 0 is a placeholder for null
     if (base_u32 == 0) {
-        if (!is_test) std.log.err("X11 server provided zero resource id base", .{});
+        if (!is_test) x11.log.err("X11 server provided zero resource id base", .{});
         return error.Protocol;
     }
     // Base must not overlap with mask bits.
     if (base_u32 & mask_u32 != 0) {
-        if (!is_test) std.log.err("X11 server provided resource id base 0x{x} that overlaps with mask 0x{x}", .{ base_u32, mask_u32 });
+        if (!is_test) x11.log.err("X11 server provided resource id base 0x{x} that overlaps with mask 0x{x}", .{ base_u32, mask_u32 });
         return error.Protocol;
     }
     // Compress base: pack the non-mask bits together.

--- a/src/x/draft.zig
+++ b/src/x/draft.zig
@@ -231,7 +231,7 @@ pub fn synchronousQueryExtension(
     try sink.writer.flush();
     const extension, _ = try source.readSynchronousReplyFull(sink.sequence, .QueryExtension);
     const result: ?x11.Extension = try .init(extension);
-    std.log.info("extension '{s}': {?}", .{ name.nativeSlice(), result });
+    x11.log.info("extension '{s}': {?}", .{ name.nativeSlice(), result });
     return result;
 }
 

--- a/src/xauth.zig
+++ b/src/xauth.zig
@@ -48,17 +48,17 @@ fn mainCompat(args_it: *ArgsIterator, environ: std16.process.Environ, io: std16.
         while (args_it.next()) |arg| {
             if (!std.mem.startsWith(u8, arg, "-")) {
                 if (maybe_cmd != null) {
-                    std.log.err("too many cmdline args", .{});
+                    x11.log.err("too many cmdline args", .{});
                     std.process.exit(1);
                 }
                 maybe_cmd = arg;
             } else if (std.mem.eql(u8, arg, "-f")) {
                 opt.auth_filename = args_it.next() orelse {
-                    std.log.err("missing authfilename after option -f", .{});
+                    x11.log.err("missing authfilename after option -f", .{});
                     std.process.exit(1);
                 };
             } else {
-                std.log.err("invalid option \"{s}\"", .{arg});
+                x11.log.err("invalid option \"{s}\"", .{arg});
                 std.process.exit(1);
             }
         }
@@ -69,7 +69,7 @@ fn mainCompat(args_it: *ArgsIterator, environ: std16.process.Environ, io: std16.
     } else if (std.mem.eql(u8, cmd, "list")) {
         try list(environ, io, opt);
     } else {
-        std.log.err("invalid command \"{s}\"", .{cmd});
+        x11.log.err("invalid command \"{s}\"", .{cmd});
         std.process.exit(1);
     }
 }
@@ -77,7 +77,7 @@ fn mainCompat(args_it: *ArgsIterator, environ: std16.process.Environ, io: std16.
 fn list(environ: std16.process.Environ, io: std16.Io, opt: Opt) !void {
     if (opt.auth_filename) |filename| {
         const file = std16.Io.Dir.cwd().openFile(io, filename, .{}) catch |err| {
-            std.log.err("open '{s}' failed with {s}", .{ filename, @errorName(err) });
+            x11.log.err("open '{s}' failed with {s}", .{ filename, @errorName(err) });
             std.process.exit(1);
         };
         defer file.close(io);
@@ -89,14 +89,14 @@ fn list(environ: std16.process.Environ, io: std16.Io, opt: Opt) !void {
             @typeInfo(x11.AuthFileKind).@"enum".fields,
         )) |kind| {
             if (x11.getAuthFilename(environ, kind, &filename_buf) catch |err| {
-                std.log.err("get auth filename ({s}) failed with {s}", .{ kind.context(), @errorName(err) });
+                x11.log.err("get auth filename ({s}) failed with {s}", .{ kind.context(), @errorName(err) });
                 continue;
             }) |filename| {
                 if (std16.Io.Dir.cwd().openFile(io, filename, .{})) |file| {
                     defer file.close(io);
                     try list2(io, file);
                 } else |err| {
-                    std.log.info("open '{s}' failed with {s}", .{ filename, @errorName(err) });
+                    x11.info("open '{s}' failed with {s}", .{ filename, @errorName(err) });
                 }
             }
         }


### PR DESCRIPTION
I made this change locally to reduce log noise when debugging some pipewire stuff, figured I might as well push it. (It's on the 0.16 branch since that's what I'm running right now.)